### PR TITLE
Support package-type "git"

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -42,6 +42,8 @@ jobs:
           mode: clear
       - if: ${{ !inputs.skip }}
         uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ inputs.package-type == 'git' && 0 || 1 }}
       - if: ${{ !inputs.skip }}
         id: current-version
         uses: infrastructure-blocks/package-version-action@v1


### PR DESCRIPTION
- By configuring actions checkout's fetch depth properly when the
user requests the git package type.
- Closes #11
