### PR TITLE
Correctly set fetch-depth to 0 for package "git"

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,7 +43,7 @@ jobs:
       - if: ${{ !inputs.skip }}
         uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ inputs.package-type == 'git' && 0 || 1 }}
+          fetch-depth: ${{ inputs.package-type != 'git' && 1 || 0 }}
       - if: ${{ !inputs.skip }}
         id: current-version
         uses: infrastructure-blocks/package-version-action@v1


### PR DESCRIPTION
- The previous ternary expressions always returned 1, because 0
is falsy. Thanks bullshit dynamic types languages. Thanks so much
for your contribution to software.
